### PR TITLE
Improve performance for endian read/write functions

### DIFF
--- a/wpiutil/examples/writelog/writelog.cpp
+++ b/wpiutil/examples/writelog/writelog.cpp
@@ -7,114 +7,100 @@
 
 #include <chrono>
 #include <iostream>
+#include <vector>
+#include <array>
+#include <string>
+#include <numeric>
 
 #include "wpi/DataLog.h"
 
-int main() {
+int main(int argc, char** argv) {
   using std::chrono::duration_cast;
   using std::chrono::high_resolution_clock;
   using std::chrono::microseconds;
 
-  {
-    auto start = high_resolution_clock::now();
-    {
-      auto log =
-          wpi::log::DoubleLog::Open("test.log", wpi::log::CD_CreateAlways);
-      if (!log) {
-        wpi::errs() << "could not open log\n";
-        return EXIT_FAILURE;
-      }
-      for (int i = 0; i < 50; ++i) log->Append(20000 * i, 1.3 * i);
-    }
-    auto stop = high_resolution_clock::now();
-    std::cout << "50 double append (test.log): "
-              << duration_cast<microseconds>(stop - start).count() << '\n';
-  }
+  int kNumRuns = 10;
 
-  {
-    auto start = high_resolution_clock::now();
-    {
-      wpi::log::DoubleLog::Config config;
-      config.periodicFlush = 1000;
-      auto log =
-          wpi::log::DoubleLog::Open("test2.log", wpi::log::CD_CreateAlways);
-      if (!log) {
-        wpi::errs() << "could not open log\n";
-        return EXIT_FAILURE;
-      }
-      for (int i = 0; i < 500000; ++i) log->Append(20000 * i, 1.3 * i);
-    }
-    auto stop = high_resolution_clock::now();
-    std::cout << "500k double append (test2.log): "
-              << duration_cast<microseconds>(stop - start).count() << '\n';
-  }
-#if 0
-  {
-    std::vector<uint8_t> data;
-    data.resize(5000);
-    auto start = high_resolution_clock::now();
-    {
-      auto log = wpi::log::DataLog::Open("test2.log", "image", "image", 0,
-                                         wpi::log::CD_OpenAlways);
-      if (!log) {
-        wpi::errs() << "could not open log\n";
-        return EXIT_FAILURE;
-      }
-      for (int i = 0; i < 1000; ++i) log->Append(20000 * i, data);
-    }
-    auto stop = high_resolution_clock::now();
-    std::cout << " time: " << duration_cast<microseconds>(stop - start).count()
-              << "\n";
-  }
-#endif
-  {
-    auto start = high_resolution_clock::now();
-    {
-      auto log = wpi::log::StringLog::Open("test-string.log",
-                                           wpi::log::CD_CreateAlways);
-      if (!log) {
-        wpi::errs() << "could not open log\n";
-        return EXIT_FAILURE;
-      }
-      for (int i = 0; i < 50; ++i) log->Append(20000 * i, "hello");
-    }
-    auto stop = high_resolution_clock::now();
-    std::cout << "50 string append (test-string.log): "
-              << duration_cast<microseconds>(stop - start).count() << '\n';
-  }
+  if (argc == 2)
+    kNumRuns = std::stoi(argv[1]);
 
-  {
-    auto start = high_resolution_clock::now();
-    {
-      auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",
-                                                wpi::log::CD_CreateAlways);
-      if (!log) {
-        wpi::errs() << "could not open log\n";
-        return EXIT_FAILURE;
-      }
-      log->Append(20000, {1, 2, 3});
-      log->Append(30000, {4, 5});
-    }
-    auto stop = high_resolution_clock::now();
-    std::cout << "Double array append (test-double-array.log): "
-              << duration_cast<microseconds>(stop - start).count() << '\n';
-  }
+  auto testVec = std::vector<std::pair<std::string, void (*)()>>();
 
-  {
-    auto start = high_resolution_clock::now();
-    {
-      auto log = wpi::log::StringArrayLog::Open("test-string-array.log",
-                                                wpi::log::CD_CreateAlways);
-      if (!log) {
-        wpi::errs() << "could not open log\n";
-        return EXIT_FAILURE;
-      }
-      log->Append(20000, {"Hello", "World"});
-      log->Append(30000, {"This", "Is", "Fun"});
+  testVec.push_back({"50 double append (test.log)", []{
+    auto log =
+        wpi::log::DoubleLog::Open("test.log", wpi::log::CD_CreateAlways);
+
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    for (int i = 0; i < 50; ++i) log->Append(20000 * i, 1.3 * i);
+  }});
+
+  testVec.push_back({"500k double append (test2.log)", []{
+    wpi::log::DoubleLog::Config config;
+    config.periodicFlush = 1000;
+    auto log =
+        wpi::log::DoubleLog::Open("test2.log", wpi::log::CD_CreateAlways);
+
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    for (uint64_t i = 0; i < 500000; ++i) log->Append(20000 * i, 1.3 * i);
+  }});
+
+  /*
+  testVec.push_back("Int array append (test2.log)", []{
+    auto data = std::vector<uint8_t>(5000);
+    auto log = wpi::log::DataLog::Open("test2.log", "image", "image", 0,
+                                       wpi::log::CD_OpenAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+    
+    for (int i = 0; i < 1000; ++i) log->Append(20000 * i, data);
+  }
+  */
+
+  testVec.push_back({"50 string append (test-string.log)", []{
+    auto log = wpi::log::StringLog::Open("test-string.log",
+                                         wpi::log::CD_CreateAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    for (int i = 0; i < 50; ++i) log->Append(20000 * i, "hello");
+  }});
+
+  testVec.push_back({"Double array append (test-double-array.log)", []{
+    auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",
+                                              wpi::log::CD_CreateAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    log->Append(20000, {1, 2, 3});
+    log->Append(30000, {4, 5});
+  }});
+
+  testVec.push_back({"String array append (test-string-array.log)", []{
+    auto log = wpi::log::StringArrayLog::Open("test-string-array.log",
+                                              wpi::log::CD_CreateAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    log->Append(20000, {"Hello", "World"});
+    log->Append(30000, {"This", "Is", "Fun"});
+  }});
+
+  for (const auto& [name, fn] : testVec) {
+    auto resVec = std::vector<microseconds::rep>();
+    std::cout << name << ": ";
+
+    for (int i = 0; i < kNumRuns; ++i) {
+      auto start = high_resolution_clock::now();
+      fn();
+      auto stop = high_resolution_clock::now();
+      resVec.push_back(duration_cast<microseconds>(stop - start).count());
     }
-    auto stop = high_resolution_clock::now();
-    std::cout << "String array append (test-string-array.log): "
-              << duration_cast<microseconds>(stop - start).count() << '\n';
+
+    std::cout << std::accumulate(resVec.begin(), resVec.end(), 0)/kNumRuns << "us\n";
   }
 
   return EXIT_SUCCESS;

--- a/wpiutil/examples/writelog/writelog.cpp
+++ b/wpiutil/examples/writelog/writelog.cpp
@@ -16,12 +16,19 @@ int main() {
   using std::chrono::microseconds;
 
   {
-    auto log = wpi::log::DoubleLog::Open("test.log", wpi::log::CD_CreateAlways);
-    if (!log) {
-      wpi::errs() << "could not open log\n";
-      return EXIT_FAILURE;
+    auto start = high_resolution_clock::now();
+    {
+      auto log =
+          wpi::log::DoubleLog::Open("test.log", wpi::log::CD_CreateAlways);
+      if (!log) {
+        wpi::errs() << "could not open log\n";
+        return EXIT_FAILURE;
+      }
+      for (int i = 0; i < 50; ++i) log->Append(20000 * i, 1.3 * i);
     }
-    for (int i = 0; i < 50; ++i) log->Append(20000 * i, 1.3 * i);
+    auto stop = high_resolution_clock::now();
+    std::cout << "50 double append (test.log): "
+              << duration_cast<microseconds>(stop - start).count() << '\n';
   }
 
   {
@@ -38,8 +45,8 @@ int main() {
       for (int i = 0; i < 500000; ++i) log->Append(20000 * i, 1.3 * i);
     }
     auto stop = high_resolution_clock::now();
-    std::cout << " time: " << duration_cast<microseconds>(stop - start).count()
-              << "\n";
+    std::cout << "500k double append (test2.log): "
+              << duration_cast<microseconds>(stop - start).count() << '\n';
   }
 #if 0
   {
@@ -61,35 +68,53 @@ int main() {
   }
 #endif
   {
-    auto log =
-        wpi::log::StringLog::Open("test-string.log", wpi::log::CD_CreateAlways);
-    if (!log) {
-      wpi::errs() << "could not open log\n";
-      return EXIT_FAILURE;
+    auto start = high_resolution_clock::now();
+    {
+      auto log = wpi::log::StringLog::Open("test-string.log",
+                                           wpi::log::CD_CreateAlways);
+      if (!log) {
+        wpi::errs() << "could not open log\n";
+        return EXIT_FAILURE;
+      }
+      for (int i = 0; i < 50; ++i) log->Append(20000 * i, "hello");
     }
-    for (int i = 0; i < 50; ++i) log->Append(20000 * i, "hello");
+    auto stop = high_resolution_clock::now();
+    std::cout << "50 string append (test-string.log): "
+              << duration_cast<microseconds>(stop - start).count() << '\n';
   }
 
   {
-    auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",
-                                              wpi::log::CD_CreateAlways);
-    if (!log) {
-      wpi::errs() << "could not open log\n";
-      return EXIT_FAILURE;
+    auto start = high_resolution_clock::now();
+    {
+      auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",
+                                                wpi::log::CD_CreateAlways);
+      if (!log) {
+        wpi::errs() << "could not open log\n";
+        return EXIT_FAILURE;
+      }
+      log->Append(20000, {1, 2, 3});
+      log->Append(30000, {4, 5});
     }
-    log->Append(20000, {1, 2, 3});
-    log->Append(30000, {4, 5});
+    auto stop = high_resolution_clock::now();
+    std::cout << "Double array append (test-double-array.log): "
+              << duration_cast<microseconds>(stop - start).count() << '\n';
   }
 
   {
-    auto log = wpi::log::StringArrayLog::Open("test-string-array.log",
-                                              wpi::log::CD_CreateAlways);
-    if (!log) {
-      wpi::errs() << "could not open log\n";
-      return EXIT_FAILURE;
+    auto start = high_resolution_clock::now();
+    {
+      auto log = wpi::log::StringArrayLog::Open("test-string-array.log",
+                                                wpi::log::CD_CreateAlways);
+      if (!log) {
+        wpi::errs() << "could not open log\n";
+        return EXIT_FAILURE;
+      }
+      log->Append(20000, {"Hello", "World"});
+      log->Append(30000, {"This", "Is", "Fun"});
     }
-    log->Append(20000, {"Hello", "World"});
-    log->Append(30000, {"This", "Is", "Fun"});
+    auto stop = high_resolution_clock::now();
+    std::cout << "String array append (test-string-array.log): "
+              << duration_cast<microseconds>(stop - start).count() << '\n';
   }
 
   return EXIT_SUCCESS;

--- a/wpiutil/src/main/native/cpp/DataLog.cpp
+++ b/wpiutil/src/main/native/cpp/DataLog.cpp
@@ -549,8 +549,13 @@ wpi::Expected<DataLog> DataLog::Open(const wpi::Twine& filename,
   DataLog log(new DataLogImpl, true);
   if (wpi::Error e = log.m_impl->DoOpen(filename, dataType, dataLayout,
                                         recordSize, disp, config))
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 8
     return std::move(e);
   return std::move(log);
+#else
+    return e;
+  return log;
+#endif
 }
 
 bool DoubleLog::Append(uint64_t timestamp, double value) {

--- a/wpiutil/src/main/native/include/wpi/DataLog.h
+++ b/wpiutil/src/main/native/include/wpi/DataLog.h
@@ -686,7 +686,11 @@ class DataLogStaticMixin {
     if (wpi::Error e =
             impl->Check(Derived::kDataType, Derived::kDataLayout,
                         Derived::kRecordSize, true, checkLayout, true))
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 8
       return std::move(e);
+#else
+      return e;
+#endif
     return Derived(impl, false);
   }
 
@@ -718,8 +722,14 @@ class DataLogStaticMixin {
     if (wpi::Error e = log.GetImpl()->DoOpen(
             filename, Derived::kDataType, Derived::kDataLayout,
             Derived::kRecordSize, disp, config))
+
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 8
       return std::move(e);
     return std::move(log);
+#else
+      return e;
+    return log;
+#endif
   }
 };
 

--- a/wpiutil/src/main/native/include/wpi/Endian.h
+++ b/wpiutil/src/main/native/include/wpi/Endian.h
@@ -89,7 +89,13 @@ template<typename value_type,
          endianness endian,
          std::size_t alignment>
 inline value_type read(const void *memory) {
-  return read<value_type, alignment>(memory, endian);
+  value_type ret;
+
+  memcpy(&ret,
+         LLVM_ASSUME_ALIGNED(
+             memory, (detail::PickAlignment<value_type, alignment>::value)),
+         sizeof(value_type));
+  return byte_swap<value_type, endian>(ret);
 }
 
 /// Read a value of a particular endianness from a buffer, and increment the


### PR DESCRIPTION
Functions which accept endianness as a template parameter can benefit from constexpr branching to determine if byteswapping should take place or not. I benchmarked using the writelog example. Before:
```50 double append (test.log): 866
500k double append (test2.log): 44470
50 string append (test-string.log): 262
Double array append (test-double-array.log): 6223
String array append (test-string-array.log): 330
```
After:
```50 double append (test.log): 697
500k double append (test2.log): 38896
50 string append (test-string.log): 257
Double array append (test-double-array.log): 6170
String array append (test-string-array.log): 257
```
These results are fairly consistent across runs (generally a ~6ms improvement for the 500k double append).