### PR TITLE
command opmodes but at the same time as regular opmodes

### DIFF
--- a/design-docs/command-contexts.md
+++ b/design-docs/command-contexts.md
@@ -28,7 +28,6 @@ Relevant library classes:
 - `Context` is described above.  Although it contains a boolean condition, it should only be used for making `Trigger`s with that context condition, so it does _not_ implement `BooleanSupplier`.
 - `Trigger` is described above.  It is made by a `Context` from a `BooleanSupplier` and implements `BooleanSupplier`.
 - `Conditions` provides static utility methods for performing logical operations on `BooleanSupplier`s.
-- `CommandOpModes` is part of [command opmodes](opmodes-commandbased.md), and provides some common `Context` instances.
 - `CommandOpMode` is part of [command opmodes](opmodes-commandbased.md) and inherits from `Context`.
 - `CommandGenericHID` is the base class of all command controller classes (described below).
 - Command controller classes (such as `CommandXboxController`) are used to create `Trigger`s associated with a controller's inputs.
@@ -45,11 +44,21 @@ The `Context` class describes when a set of `Trigger`s should be active.
 
 To avoid inadvertently making bindings that are active in more opmodes than expected, `Context`s can only be made from opmodes, or from an opmode type such as all opmodes or all teleop opmodes.
 
-To prevent making `Context`s which can be true regardless of opmode (aside from `CommandOpModes.all` and `Context`s built from it), the only ways to create a `Context` are from the `CommandOpModes` static `Context`s, a `CommandOpMode`, a logical OR of existing `Context`s, and a logical AND of a `Context` with an arbitrary condition.  (Note that allowing a logical OR of a `Context` with an arbitrary condition would defeat this goal.)
+To prevent making `Context`s which can be true regardless of opmode (aside from `Context.all` and `Context`s built from it), the only ways to create a `Context` are from the static `Context`s, a `CommandOpMode`, a logical OR of existing `Context`s, and a logical AND of a `Context` with an arbitrary condition.  (Note that allowing a logical OR of a `Context` with an arbitrary condition would defeat this goal.)
+
+The `Context` class also contains static constants.
 
 ```java
 public class Context {
-  // used by CommandOpMode and the internals of CommandOpModes
+  // always true
+  public static final Context all;
+
+  // true when the given robot mode is selected, regardless of enabled/disabled state
+  public static final Context allAuto;
+  public static final Context allTeleop;
+  public static final Context allTest;
+
+  // used by CommandOpMode and the internals
   protected Context(BooleanSupplier);
 
   // creates a Trigger with the given base condition
@@ -63,27 +72,6 @@ public class Context {
 
 Open question: Should we add `Context.trigger()` and `Context.trigger(EventLoop)` to create `Trigger`s whose context condition is the context and whose base condition is the context being active?  (Note that a constant true base condition would not have any rising or falling edges to trigger Commands.)
 
-## CommandOpModes
-
-In addition to providing the factories described in [command opmodes](opmodes-commandbased.md), the `CommandOpModes` class provides provides static `Context` instances for types of opmodes.  Note that the number of opmodes of a particular type is unbounded\!
-
-```java
-public final class CommandOpModes {
-  // always true
-  public static final Context all;
-
-  // true when the given robot mode is selected, regardless of enabled/disabled state
-  public static final Context allAuto;
-  public static final Context allTeleop;
-  public static final Context allTest;
-
-  // the autonomous(), teleoperated(), and test() CommandOpMode factories still exist
-}
-```
-
-Open question: Are allAuto, allTeleop, and allTest worth defining for users?
-Open question: Should allTeleop be renamed to allTeleoperated to match the CommandOpMode factory?
-
 ## CommandOpMode
 
 In addition to providing the `Trigger`s described in [command opmodes](opmodes-commandbased.md), the `CommandOpMode` class extends `Context`, allowing any opmode to be used wherever a context is expected.  The condition of the `Context` is when the opmode is selected (regardless of enabled/disabled status).
@@ -91,7 +79,7 @@ In addition to providing the `Trigger`s described in [command opmodes](opmodes-c
 Note that the `selected` trigger must have a base condition that has rising and falling edges.
 
 ```java
-public class CommandOpMode extends Context {
+public class CommandOpMode extends Context implements OpMode {
   public final Trigger selected = trigger(...is selected...);
   public final Trigger disabled = selected.and(RobotState::isDisabled);
   public final Trigger enabled = selected.and(RobotState::isEnabled);
@@ -192,18 +180,18 @@ public class Robot extends CommandRobot {
 
   public Robot() {
     // Automatically disable and retract the intake whenever the ball storage is full in any opmode
-    CommandOpModes().any.trigger(storage.hasCargo).onTrue(intake.retractCommand());
+    Context.all.trigger(storage.hasCargo).onTrue(intake.retractCommand());
 
     // Create auto opmodes
-    addSimpleAuto(CommandOpModes.autonomous("Simple Auto"));
+    addSimpleAuto(autonomous("Simple Auto"));
     addPathAuto("drive and turn");
 
     // Create teleop opmodes
-    var arcadeTeleop = CommandOpModes.teleoperated("Arcade Drive");
+    var arcadeTeleop = teleoperated("Arcade Drive");
     addArcadeDriveBindings(arcadeTeleop);
     addIntakeBindings(arcadeTeleop);
 
-    var tankTeleop = CommandOpModes.teleoperated("Tank Drive");
+    var tankTeleop = teleoperated("Tank Drive");
     addTankDriveBindings(tankTeleop);
     addIntakeBindings(tankTeleop);
   }
@@ -215,7 +203,7 @@ public class Robot extends CommandRobot {
 
   private void addPathAuto(String path) {
     // A complex autonomous opmode that loads a path when selected in the DS while still disabled
-    CommandOpMode opmode = CommandOpModes.autonomous(path, "Follow Path");
+    CommandOpMode opmode = autonomous(path, "Follow Path");
     opmode.selected.onTrue(Commands.runOnce(() -> Paths.loadPath(path)));
     opmode.running.whileTrue(Autos.followPath(this, path));
   }

--- a/design-docs/opmodes-commandbased.md
+++ b/design-docs/opmodes-commandbased.md
@@ -26,12 +26,16 @@ The design for multiple opmodes in the command-based framework extends the curre
 
 A unique `RobotBase` class is also provided that allows users to create command-based OpModes using factory functions. This class extends `OpModeRobot` and uses `OpModeRobot`'s functions for OpMode registration and initialization.
 
+## `Context`s
+
+This design uses the idea of [command contexts](command-contexts.md) to control when triggers are active. As describes in that document, a `CommandOpMode` is a `Context` whose condition is it being selected.
+
 ## CommandOpMode
 
 The `CommandOpMode` class provides triggers to enable users to tie into each section of a opmode's lifetime.  Triggers have the ability to be tied to specific commands or actions on both transitions (e.g. false to true, true to false) and while the condition is in a particular state.  The framework will ensure these triggers always start in false state, even if code is started while attached to the field, so that it's safe to attach an action to the false to true transition of these triggers.
 
 ```java
-public class CommandOpMode implements OpMode {
+public class CommandOpMode extends Context implements OpMode {
   // opmode is selected on DS (regardless of enabled or disabled)
   public final Trigger selected;
 
@@ -53,7 +57,7 @@ The `CommandRobot` class is the base class for the user's command-based `Robot` 
 public class CommandRobot extends OpModeRobot {
   // this is run periodically by all OpModes after the scheduler is run
   public void robotPeriodic() {}
-    
+
   // these are the factory functions for creating opmodes
   // they return CommandOpModes that can be used to tie triggers to opmodes on robot initialization
   // overloads with default values for group, description, and color are also provided
@@ -127,7 +131,7 @@ public class Robot extends CommandRobot {
   @Override
   public void robotPeriodic() {
     // this code is called periodically in all robot modes of operation after the scheduler is run
-      
+
     // run vision processing in preparation for next loop
     vision.process();
 
@@ -174,10 +178,18 @@ public class ArcadeTeleop extends CommandOpMode {
 
 # Drawbacks
 
-The ability to mix command-based and non-command-based opmodes in a single project is a nice feature, but it can potentially be confusing for teams who are not familiar with the command-based framework.
+The ability to mix command-based and non-command-based opmodes in a single project is a nice feature, but it can potentially be confusing for teams who are not familiar with the command-based framework. This is discussed further in the Alternatives section.
 
 # Trades
 
 - Binding teleop joysticks is very verbose if different behavior is desired in different teleop opmodes.  Maybe add to CommandOpMode a separate event loop that's only active in that opmode?  At the minimum, it may make sense to add CommandOpMode overloads to joysticks so users could write `driverController.x(teleop)` instead of `teleop.running.and(driverController.x())`?
 
-# Unresolved Questions
+# Alternatives
+
+## Not Use `OpModeRobot` for Command-Based Opmodes
+
+An alternative to this proposal is to not use `OpModeRobot` as the base class for command-based robots, and instead have a fully separate mechanism to register opmodes in `CommandRobot`. This means opmodes registered with annotations are not registered automatically. This alternative also uses `CommandRobot`'s periodic function to run the command scheduler, meaning that the command scheduler is run in all modes, so making traditional `LinearOpMode` or `PeriodicOpMode` opmodes would be heavily discouraged as the command scheduler would still run. Teams would also be responsible for manually registering those opmodes, as `CommandRobot` would only provide methods to register command-based opmodes.
+
+The goal of that alternative is to separate command-based and non-command-based opmodes by design, though teams can still mix them in the same project by manually creating registration functions (probably by copying what `OpModeRobot` does). Less importantly, that design's version of the `CommandOpMode` class does not actually implement the `OpMode` interface, and the actual `OpMode` implementations are provided by another class. That design makes relatively little sense. Command-based opmodes should be opmodes, and as such they should be able to be used with the rest of the OpMode framework.
+
+The largest advantage of mixing command-based and non-command-based opmodes is it allows for rapid testing of mechanisms, as teams can make opmodes that

--- a/design-docs/opmodes-commandbased.md
+++ b/design-docs/opmodes-commandbased.md
@@ -4,7 +4,7 @@ This document describes how opmodes are implemented in command-based projects.
 
 # Motivation
 
-See [opmodes](opmodes.md) for the motivation for adding operator selectable opmodes to the core robot structure.  For command-based programs, the entire robot program is structured around command-based subsystems and commands tied to robot states and inputs, with everything constructed during initialization, so for more natural integration with the rest of the command-based framework, a different approach than the annotation-based approach used for periodic and linear opmodes is warranted.
+See [opmodes](opmodes.md) for the motivation for adding operator selectable opmodes to the core robot structure.  For command-based programs, the entire robot program is structured around command-based subsystems and commands tied to robot states and inputs, where everything can be constructed during initialization, so for more natural integration with the rest of the command-based framework, a different approach than the annotation-based approach used for periodic and linear opmodes is warranted. It will also be possible for teams to mix command-based and non-command-based opmodes in the same project, using annotations.
 
 # Background
 
@@ -14,38 +14,24 @@ The command-based framework is an approach and implementation for structuring ro
 
 The 2025 version of the command-based framework provides a [`RobotModeTriggers`](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj2/command/button/RobotModeTriggers.html) class that provides triggers for each of the fixed robot modes (autonomous, teleop, test, and disabled) available in the 2025 FRC system.
 
+In addition, third-party command-based frameworks inspired by WPILib's are also used by many FTC teams. While these frameworks are are developed by FTC students and mentors and are not officially supported by FIRST or the FTC SDK, they are widely used by FTC teams as they offer similar benefits to WPILib's command-based framework, most notably the ability to reuse commands between OpModes. The core concepts of command-based programming are the same, with users defining subsystems and commands, but the usage patterns are different. Teams create OpModes and register them with annotations, and each OpMode typically has its own set of triggers and commands, often registered in the OpMode's `start` method. Because command-based OpModes are registered with annotations just like standard Opmodes, it is possible (and somewhat common) to mix command-based and non-command-based OpModes in the same project.
+
 # Design
 
-Unlike the non-command-based approach, the command-based framework generally favors a design where commands can be used in all modes and explicit periodic code is discouraged.  In addition, the general approach for "modern" commands eschews classes, preferring a "fluent" method chained builder approach.  To support this, opmode registration for command-based is performed with function calls instead of separate annotated classes.
+Unlike the non-command-based approach, the command-based framework generally favors a design where commands can be used in all modes and explicit periodic code is discouraged.  In addition, the general approach for "modern" commands eschews classes, preferring a "fluent" method chained builder approach.  To support this, opmode registration for command-based can be performed either via annotations or via factory functions.
 
 The design for multiple opmodes in the command-based framework extends the current `RobotModeTriggers` approach in two important ways:
 - Instead of fixed modes, opmodes are explicitly created by the user
 - The opmodes provide multiple triggers; this makes it possible to tie behaviors to DS selection/initialization as well as the enabled period
 
-A unique `RobotBase` class is also provided that always runs the command scheduler periodically in all modes, including disabled.  This means it is not possible to mix command-based opmodes and non-command-based opmodes; all opmodes in a command-based project must be command-based opmodes.
-
-## CommandOpModes
-
-The `CommandOpModes` class provides factory functions for creating opmodes.
-
-```java
-public final class CommandOpModes {
-  // these register the opmode and return a new CommandOpMode object for it
-  // (also includes default versions so group and description are optional)
-  //
-  // Calling twice with the same name is a runtime error (exception is thrown)
-  public static CommandOpMode autonomous(String name, String group, String description) {...}
-  public static CommandOpMode teleoperated(String name, String group, String description) {...}
-  public static CommandOpMode test(String name, String group, String description) {...}
-}
-```
+A unique `RobotBase` class is also provided that allows users to create command-based OpModes using factory functions. This class extends `OpModeRobot` and uses `OpModeRobot`'s functions for OpMode registration and initialization.
 
 ## CommandOpMode
 
 The `CommandOpMode` class provides triggers to enable users to tie into each section of a opmode's lifetime.  Triggers have the ability to be tied to specific commands or actions on both transitions (e.g. false to true, true to false) and while the condition is in a particular state.  The framework will ensure these triggers always start in false state, even if code is started while attached to the field, so that it's safe to attach an action to the false to true transition of these triggers.
 
 ```java
-public class CommandOpMode {
+public class CommandOpMode implements OpMode {
   // opmode is selected on DS (regardless of enabled or disabled)
   public final Trigger selected;
 
@@ -57,26 +43,23 @@ public class CommandOpMode {
 }
 ```
 
+`CommandOpMode` will use a similar mechanism to `PeriodicOpMode` for periodically running the command scheduler while the OpMode is running. It also overrides `disabledPeriodic` to run the scheduler in disabled mode.
+
 ## CommandRobot
 
 The `CommandRobot` class is the base class for the user's command-based `Robot` class.  It also implements the private library machinery for robot startup and robot execution, and provides factory functions for creating opmodes.
 
 ```java
-public abstract class CommandRobot {
-  public void beforeScheduler() {
-    // this code is called periodically in all robot modes of operation before the scheduler is run
-  }
-
-  public void afterScheduler() {
-    // this code is called periodically in all robot modes of operation after the scheduler is run
-  }
-
-  // exposed so users may override it if desired, but generally shouldn't be necessary to do so
-  public void robotPeriodic() {
-    beforeScheduler();
-    CommandScheduler.run();
-    afterScheduler();
-  }
+public class CommandRobot extends OpModeRobot {
+  // this is run periodically by all OpModes after the scheduler is run
+  public void robotPeriodic() {}
+    
+  // these are the factory functions for creating opmodes
+  // they return CommandOpModes that can be used to tie triggers to opmodes on robot initialization
+  // overloads with default values for group, description, and color are also provided
+  public final CommandOpMode autonomous(String name, String group, String description, Color textColor, Color backgroundColor);
+  public final CommandOpMode teleop(String name, String group, String description, Color textColor, Color backgroundColor);
+  public final CommandOpMode test(String name, String group, String description, Color textColor, Color backgroundColor);
 }
 ```
 
@@ -131,45 +114,22 @@ public class Robot extends CommandRobot {
 
   private void addSimpleAuto() {
     // A simple autonomous opmode
-    CommandOpModes.autonomous("Simple Auto").running.whileTrue(Autos.simpleAuto(this));
+    autonomous("Simple Auto").running.whileTrue(Autos.simpleAuto(this));
   }
 
   private void addPathAuto(String path) {
     // A complex autonomous opmode that loads a path when selected in the DS while still disabled
-    CommandOpMode opmode = CommandOpModes.autonomous(path, "Follow Path");
+    CommandOpMode opmode = autonomous(path, "Follow Path");
     opmode.selected.onTrue(Commands.runOnce(() -> Paths.loadPath(path)));
     opmode.running.whileTrue(Autos.followPath(this, path));
   }
 
-  private void addArcadeTeleop() {
-    // A teleop opmode with joystick and button controls
-    CommandOpMode opmode = CommandOpModes.teleoperated("teleop");
-
-    var driverController = new CommandXboxController(1);
-
-    // Control the drive with split-stick arcade controls
-    m_drive.setDefaultCommand(
-        opmode,
-        drive.arcadeDriveCommand(
-            () -> -driverController.getLeftY(), () -> -driverController.getRightX()));
-
-    // Deploy the intake with the X button
-    opmode.running.and(driverController.x()).onTrue(intake.intakeCommand());
-    // Retract the intake with the Y button
-    opmode.running.and(driverController.y()).onTrue(intake.retractCommand());
-  }
-
   @Override
-  public void beforeScheduler() {
-    // this code is called periodically in all robot modes of operation before the scheduler is run
-
-    // make sure we process vision inputs ahead of scheduled commands
-    vision.process();
-  }
-
-  @Override
-  public void afterScheduler() {
+  public void robotPeriodic() {
     // this code is called periodically in all robot modes of operation after the scheduler is run
+      
+    // run vision processing in preparation for next loop
+    vision.process();
 
     // output telemetry from all subsystems
     Telemetry.log("drive", drive);
@@ -188,18 +148,36 @@ public class Autos {
 }
 ```
 
+Teleop:
+```java
+@Teleop(name = "Arcade Teleop")
+public class ArcadeTeleop extends CommandOpMode {
+  CommandXboxController driverController = new CommandXboxController(1);
+
+  public ArcadeTeleop(CommandRobot robot) {
+    super(robot);
+
+    // Set the default command for the drive subsystem to use arcade drive.
+    robot.drive.setDefaultCommand(this,
+        robot.drive.arcadeDriveCommand(
+            () -> -driverController.getLeftY(),
+            () -> -driverController.getRightX()));
+
+    // Deploy the intake with the X button
+    running.and(driverController.x()).onTrue(robot.intake.intakeCommand());
+
+    // Retract the intake with the Y button
+    running.and(driverController.y()).onTrue(robot.intake.retractCommand());
+  }
+}
+```
+
 # Drawbacks
 
-Command-based opmodes and non-command-based opmodes cannot be intermixed in a single project.  The benefit of this is cleaner integration with the rest of the command-based framework, including proper handling of periodic subsystem behaviors in disabled mode, which otherwise might be a common error for teams.  In addition, command-based subsystems would need to expose significant non-command-based behaviors to make them usable in non-command-based opmodes, which would likely create potential for additional issues in writing normal command-based code (where subsystem implementation details should be black-boxed from commands).
-
-# Alternatives
-
-Make command-based opmodes interoperate with non-command opmodes by using the same base class and only having the scheduler run if one of those opmodes is active.
+The ability to mix command-based and non-command-based opmodes in a single project is a nice feature, but it can potentially be confusing for teams who are not familiar with the command-based framework.
 
 # Trades
 
 - Binding teleop joysticks is very verbose if different behavior is desired in different teleop opmodes.  Maybe add to CommandOpMode a separate event loop that's only active in that opmode?  At the minimum, it may make sense to add CommandOpMode overloads to joysticks so users could write `driverController.x(teleop)` instead of `teleop.running.and(driverController.x())`?
-- Is the `beforeScheduler()` / `afterScheduler()` split beneficial?  Or should we just have `robotPeriodic()` showing the `CommandScheduler.run()` code in it like we do in 2025?
-- Related: should we remove the built-in `periodic()` from the `Subsystem` interface?  Split it into before/after?
 
 # Unresolved Questions

--- a/design-docs/opmodes-commandbased.md
+++ b/design-docs/opmodes-commandbased.md
@@ -192,4 +192,6 @@ An alternative to this proposal is to not use `OpModeRobot` as the base class fo
 
 The goal of that alternative is to separate command-based and non-command-based opmodes by design, though teams can still mix them in the same project by manually creating registration functions (probably by copying what `OpModeRobot` does). Less importantly, that design's version of the `CommandOpMode` class does not actually implement the `OpMode` interface, and the actual `OpMode` implementations are provided by another class. That design makes relatively little sense. Command-based opmodes should be opmodes, and as such they should be able to be used with the rest of the OpMode framework.
 
-The largest advantage of mixing command-based and non-command-based opmodes is it allows for rapid testing of mechanisms, as teams can make opmodes that
+The largest advantage of mixing command-based and non-command-based opmodes is it allows for rapid testing of mechanisms, as teams can make opmodes that test specific behavior without having to write a full subsystem with commands for the mechanism, and then switch to the full subsystem when the mechanism is ready for use. 
+
+Since this proposal only runs the command scheduler when a `CommandOpMode` is selected on the Driver Station, it does not interfere with the behavior of `LinearOpMode` or `PeriodicOpMode` opmodes, so it is okay that this proposal allows command-based and traditional opmodes to be mixed in the same project.


### PR DESCRIPTION
I strongly believe it makes the most sense for command-based opmodes and 'regular' opmodes to be intermixable, and also that separating command opmodes into classes (like regular opmodes) makes more digestible and maintainable code. 

Here are a couple of examples of command-based opmodes from FTC team 23954:
- [teleop with commands](https://github.com/Robo-Phantoms/Decode25-26/blob/main/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/CatapultOpModes/CatapultTeleop.java); note that here, triggers are bound in the `onStartButtonPressed` method (equivalent to WPILib's `PeriodicOpMode.start` method). This is so that triggers are not bound during the initialize phase of the OpMode (which will not exist anymore anyway), and would be equivalent to binding them in the constructor using `running.and(/* whatever trigger */)`.
- [autonomous with commands](https://github.com/Robo-Phantoms/Decode25-26/blob/main/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/CatapultOpModes/LM2RedCatapultAuto.java); note that here, the drive commands aren't built until `onInit` (this is because hardware is inaccessible until the initialize phase of the opmode in ftc rn), but using wpilib they could be created in the opmode constructor instead.
